### PR TITLE
The space issue between service type names when using brackets is res…

### DIFF
--- a/docroot/modules/custom/erpw_custom/erpw_custom.module
+++ b/docroot/modules/custom/erpw_custom/erpw_custom.module
@@ -804,9 +804,9 @@ function erpw_custom_entity_presave(EntityInterface $entity) {
   // For service type content type.
   if ($entity->getEntityTypeId() == 'node' && $entity->getType() == 'service_type') {
     $node_title = trim($entity->get('title')->value);
-    if (strpos($node_title, '(') !== FALSE) {
-      $node_title = preg_replace('/\s+/', '', $node_title);
-    }
+    // if (strpos($node_title, '(') !== FALSE) {
+    //   $node_title = preg_replace('/\s+/', '', $node_title);
+    // }
     if (preg_match("/'/u", $node_title)) {
       $node_title = str_replace("'", '', $node_title);
     }


### PR DESCRIPTION
Resolved.
Before : 
![image](https://user-images.githubusercontent.com/66715775/223996935-8a30921c-75a5-4b91-ba3c-0a1e3c5c43fc.png)

After:
![image](https://user-images.githubusercontent.com/66715775/223996633-53ee71c6-fd3c-45f3-8919-ed7badbb0e5e.png)


#1391 


# Checklist:

- [] Ready to Merge
