### PR TITLE
Limit creation of a webform to one service type only.

### DIFF
--- a/docroot/modules/custom/erpw_webform/erpw_webform.module
+++ b/docroot/modules/custom/erpw_webform/erpw_webform.module
@@ -48,6 +48,6 @@ function erpw_webform_entity_type_build(array &$entity_types) {
 
   // Add a form for a custom node form without overriding the default
   // node form. To override the default node form, use hook_entity_type_alter().
-  $entity_types['webform']
-    ->setFormClass('add', 'Drupal\erpw_webform\Form\WebformAddForm');
+  $entity_types['webform']->setFormClass('duplicate', 'Drupal\erpw_webform\Form\WebformAddForm');
+  $entity_types['webform']->setFormClass('add', 'Drupal\erpw_webform\Form\WebformAddForm');
 }

--- a/docroot/modules/custom/erpw_webform/src/Form/WebformAddForm.php
+++ b/docroot/modules/custom/erpw_webform/src/Form/WebformAddForm.php
@@ -5,7 +5,6 @@ namespace Drupal\erpw_webform\Form;
 use Drupal\webform\WebformEntityAddForm;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\webform\Entity\Webform;
 
 /**
  * Provides an overrided webform add form.
@@ -77,7 +76,7 @@ class WebformAddForm extends WebformEntityAddForm {
       "#empty_option" => t('- Select -'),
       '#options' => $service_type_options,
     ];
-    $form['current_domain_webform'] = $current_domain;
+    $form_state->set('current_domain_webform', $current_domain);
     return parent::form($form, $form_state);
   }
 
@@ -87,8 +86,8 @@ class WebformAddForm extends WebformEntityAddForm {
   public function validateForm(array &$form, FormStateInterface $form_state) {
     $query = $this->entityTypeManager->getStorage('webform')->getQuery();
     $webform_ids = $query->condition('category', 'eRPW')->execute();
-    $webforms = Webform::loadMultiple($webform_ids);
-    $current_domain = $form_state->getCompleteForm()['current_domain_webform'];
+    $webforms = $this->entityTypeManager->getStorage('webform')->loadMultiple($webform_ids);
+    $current_domain = $form_state->get('current_domain_webform');
     foreach ($webforms as $webform) {
       $settings = $webform->getThirdPartySetting('erpw_webform', 'webform_service_type_map');
       if (isset($settings[$current_domain])) {
@@ -110,7 +109,7 @@ class WebformAddForm extends WebformEntityAddForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
-    $current_domain = $form_state->getCompleteForm()['current_domain_webform'];
+    $current_domain = $form_state->get('current_domain_webform');
     $webform = $this->getEntity();
     $checkArray[$current_domain][] = $form_state->getValues()['service_type'];
     $webform->setThirdPartySetting('erpw_webform', 'webform_service_type_map', $checkArray);


### PR DESCRIPTION
Overrided the current add webform to custom form using preprocess function.

In the custom form added a new field for service types along with translation check.
In the form validation checked for all the existing webforms thirdparty settings for service type ID. 
If match is found error is thrown , else a new ThirdPartySettings is saved with the webform.

## Description
Summary: 

JIRA Ticket: https://srijan.atlassian.net/browse/<ticket_no>


# Checklist:

- [] Ready to Merge
