### PR TITLE
Fix location and content inconsistencies for forms.

### DIFF
--- a/docroot/modules/custom/erpw_custom/src/Form/SignUpForm.php
+++ b/docroot/modules/custom/erpw_custom/src/Form/SignUpForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\erpw_custom\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Ajax\HtmlCommand;
 use Drupal\Core\Ajax\AjaxResponse;
@@ -63,6 +64,13 @@ class SignUpForm extends FormBase {
   protected $domainNegotiator;
 
   /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * A userId variable.
    *
    * @var Drupal\erpw_custom
@@ -85,9 +93,11 @@ class SignUpForm extends FormBase {
 
   /**
    * {@inheritdoc}
-   * 
-   * * @param \Drupal\domain\DomainNegotiatorInterface $domain_negotiator
+   *
+   * @param \Drupal\domain\DomainNegotiatorInterface $domain_negotiator
    *   The domain negotiator service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
    */
   public function __construct(
     Connection $database,
@@ -97,7 +107,8 @@ class SignUpForm extends FormBase {
     FormBuilderInterface $form_builder,
     LocationService $location_service,
     ErpwPathwayService $erpwp_athway,
-    DomainNegotiatorInterface $domain_negotiator,) {
+    DomainNegotiatorInterface $domain_negotiator,
+    ConfigFactoryInterface $configFactory) {
 
     $this->database = $database;
     $this->entityTypeManager = $entity_type_manager;
@@ -107,6 +118,7 @@ class SignUpForm extends FormBase {
     $this->locationService = $location_service;
     $this->erpwpathway = $erpwp_athway;
     $this->domainNegotiator = $domain_negotiator;
+    $this->configFactory = $configFactory;
   }
 
   /**
@@ -121,7 +133,8 @@ class SignUpForm extends FormBase {
       $container->get('form_builder'),
       $container->get('erpw_location.location_services'),
       $container->get('erpw_pathway.erpw_location_form'),
-      $container->get('domain.negotiator')
+      $container->get('domain.negotiator'),
+      $container->get('config.factory')
     );
   }
 
@@ -393,9 +406,9 @@ class SignUpForm extends FormBase {
     ];
     $current_user = $this->entityTypeManager->getStorage('user')->load($this->currentUser->id());
 
-    //Get active domain's tid
+    // Get active domain's tid.
     $domain = $this->domainNegotiator->getActiveDomain();
-    $config = \Drupal::config('domain.location.' . $domain->get('id'));
+    $config = $this->configFactory->get('domain.location.' . $domain->get('id'));
     $domain_tid = $config->get('location');
 
     $location_id = (!$current_user->get('field_location')->isEmpty()) ?

--- a/docroot/modules/custom/erpw_location/modules/erpw_pathway/erpw_pathway.services.yml
+++ b/docroot/modules/custom/erpw_location/modules/erpw_pathway/erpw_pathway.services.yml
@@ -8,6 +8,8 @@ services:
       - "@erpw_pathway.erpw_location_form"
       - "@current_user"
       - "@erpw_custom.custom_service"
+      - "@domain.negotiator"
+      - "@config.factory"
     tags:
       - { name: 'event_subscriber' }
   erpw_pathway.erpw_location_form:

--- a/docroot/modules/custom/erpw_location/modules/erpw_pathway/src/EventSubscriber/EntityLocationSubscriber.php
+++ b/docroot/modules/custom/erpw_location/modules/erpw_pathway/src/EventSubscriber/EntityLocationSubscriber.php
@@ -2,12 +2,14 @@
 
 namespace Drupal\erpw_pathway\EventSubscriber;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\core_event_dispatcher\Event\Form\FormAlterEvent;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\domain\DomainNegotiatorInterface;
 use Drupal\node\NodeInterface;
 use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -92,14 +94,32 @@ class EntityLocationSubscriber implements EventSubscriberInterface {
   protected $currentUser;
 
   /**
+   * The domain negotiator service.
+   *
+   * @var \Drupal\domain\DomainNegotiatorInterface
+   */
+  protected $domainNegotiator;
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager,
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
     LocationService $location_service,
     RouteMatchInterface $route_match,
     ErpwPathwayService $erpw_pathway_service,
     AccountProxyInterface $current_user,
-    ErpwCustomService $erpw_custom_service) {
+    ErpwCustomService $erpw_custom_service,
+    DomainNegotiatorInterface $domain_negotiator,
+    ConfigFactoryInterface $config_factory
+  ) {
     self::$entityTypeManager = $entity_type_manager;
     self::$locationService = $location_service;
     $this->erpwPathwayService = $erpw_pathway_service;
@@ -107,6 +127,8 @@ class EntityLocationSubscriber implements EventSubscriberInterface {
     $this->currentUser = $current_user;
     $this->locationEntity = $location_service;
     $this->erpwCustomService = $erpw_custom_service;
+    $this->domainNegotiator = $domain_negotiator;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -120,13 +142,17 @@ class EntityLocationSubscriber implements EventSubscriberInterface {
     $form_id = $event->getFormId();
     $form_state = $event->getFormState();
 
-    if (in_array($form_id,
-      [
-        'node_referral_path_way_form',
-        'node_referral_path_way_edit_form',
-        'node_service_provider_form',
-        'node_service_provider_edit_form',
-      ])) {
+    if (
+      in_array(
+        $form_id,
+        [
+          'node_referral_path_way_form',
+          'node_referral_path_way_edit_form',
+          'node_service_provider_form',
+          'node_service_provider_edit_form',
+        ]
+      )
+    ) {
       $parent_list = [];
       $node = $this->routeMatch->getParameter('node');
       if (empty($form_state->getTriggeringElement()['#level']) && $node instanceof NodeInterface) {
@@ -155,14 +181,27 @@ class EntityLocationSubscriber implements EventSubscriberInterface {
           $permission = '';
           break;
       }
-      if ($this->currentUser->id() != 1 && !$current_user->hasRole('administrator') && $current_user->hasPermission($permission)) {
-        $location_id = '';
-        if ($current_user->hasField('field_location') && !$current_user->get('field_location')->isEmpty()) {
-          $location_id = $current_user->get('field_location')->getValue()[0]['target_id'];
+
+      // Get active domain's tid.
+      $domain = $this->domainNegotiator->getActiveDomain();
+      $config = $this->configFactory->get('domain.location.' . $domain->get('id'));
+      $domain_tid = $config->get('location');
+
+      // Check if location is set for user, else use current location.
+      $location_id = (!$current_user->get('field_location')->isEmpty()) ?
+        $current_user->get('field_location')->getValue()[0]['target_id'] : $domain_tid;
+      $ptids = $parent_list = [];
+      if (!isset($form_state->getTriggeringElement()['#level'])
+      && $current_user->get('uid')->value != 1 && !$current_user->hasRole('administrator')) {
+        $parent_list = self::$locationService->getAllAncestors($location_id);
+        if ($current_user->hasPermission($permission)) {
+          $ptids = $parent_list;
         }
-        $ptids = self::$locationService->getAllAncestors($location_id);
-        $parent_list = empty($parent_list) ? array_values($ptids) : $parent_list;
+        else {
+          $ptids = [reset($parent_list)];
+        }
       }
+
       $form = $this->erpwPathwayService->getLocationForm($form, $form_state, $parent_list, $ptids);
       // Form submit handler.
       $form['actions']['submit']['#submit'][] = [$this, 'eprwSubmitHandler'];

--- a/docroot/modules/custom/erpw_location/src/Form/ManageLocationForm.php
+++ b/docroot/modules/custom/erpw_location/src/Form/ManageLocationForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\erpw_location\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Form\FormStateInterface;
@@ -13,6 +14,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\domain\DomainNegotiatorInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -80,6 +82,20 @@ class ManageLocationForm extends FormBase {
   protected $tempStoreFactory;
 
   /**
+   * The Domain negotiator.
+   *
+   * @var \Drupal\domain\DomainNegotiatorInterface
+   */
+  protected $domainNegotiator;
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * ManageLocation constructor.
    *
    * @param \Psr\Log\LoggerChannelFactory $logger
@@ -102,6 +118,10 @@ class ManageLocationForm extends FormBase {
    *   The current user.
    * @param \Drupal\erpw_location\LocationService $location_service
    *   The location service.
+   * @param \Drupal\domain\DomainNegotiatorInterface $domain_negotiator
+   *   The domain negotiator service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
    */
   public function __construct(
     LoggerChannelFactory $logger,
@@ -113,7 +133,10 @@ class ManageLocationForm extends FormBase {
     LanguageManagerInterface $language_manager,
     PrivateTempStoreFactory $temp_store_factory,
     AccountProxyInterface $current_user,
-    LocationService $location_service) {
+    LocationService $location_service,
+    DomainNegotiatorInterface $domain_negotiator,
+    ConfigFactoryInterface $configFactory
+  ) {
 
     $this->logger = $logger;
     $this->connection = $connection;
@@ -125,6 +148,8 @@ class ManageLocationForm extends FormBase {
     $this->tempStoreFactory = $temp_store_factory;
     $this->currentUser = $current_user;
     $this->locationService = $location_service;
+    $this->domainNegotiator = $domain_negotiator;
+    $this->configFactory = $configFactory;
   }
 
   /**
@@ -141,7 +166,9 @@ class ManageLocationForm extends FormBase {
       $container->get('language_manager'),
       $container->get('tempstore.private'),
       $container->get('current_user'),
-      $container->get('erpw_location.location_services')
+      $container->get('erpw_location.location_services'),
+      $container->get('domain.negotiator'),
+      $container->get('config.factory')
     );
   }
 
@@ -186,15 +213,10 @@ class ManageLocationForm extends FormBase {
     }
     if (!$form_state->getUserInput()) {
       $user = $this->entityManager->getStorage('user')->load($this->currentUser->id());
-
-      $location_value = '';
-      if ($user->hasField('field_location') && !$user->get('field_location')->isEmpty()) {
-        $location_value = $user->field_location->getValue()[0]['target_id'];
-      }
-
-      if (!empty($location_levels_tid)) {
-        $location_value = $location_levels_tid;
-      }
+      // Get active domain's tid.
+      $domain = $this->domainNegotiator->getActiveDomain();
+      $config = $this->configFactory->get('domain.location.' . $domain->get('id'));
+      $location_value = $config->get('location');
 
       $ancestors = $this->entityManager->getStorage('taxonomy_term')->loadAllParents($location_value);
       $upper_ancestors = array_reverse(array_keys($ancestors));
@@ -208,8 +230,11 @@ class ManageLocationForm extends FormBase {
         $country_tid = $this->locationService->getLocationSingleEntityIdByTid($upper_ancestors[0]);
       }
       if (!empty($country_tid)) {
-        $link = Link::createFromRoute($this->t('Click to Change Country'), 'erpw_location.user_location_manage',
-        ['id' => $country_tid, 'page' => 'location'])->toString();
+        $link = Link::createFromRoute(
+          $this->t('Click to Change Country'),
+          'erpw_location.user_location_manage',
+          ['id' => $country_tid, 'page' => 'location']
+        )->toString();
       }
       else {
         $link = "";
@@ -302,14 +327,17 @@ class ManageLocationForm extends FormBase {
           }
         }
 
-        $delete_url = $this->urlGenerator->generateFromRoute('erpw_location.delete_location',
-           ['tid' => $tid]
-         );
-        $edit_url = $this->urlGenerator->generateFromRoute('erpw_location.edit_location',
-           ['id' => $tid]
-         );
-        $view_url = $this->urlGenerator->generateFromRoute('erpw_location.view_location',
-           ['tid' => $tid, 'mode' => 'view']
+        $delete_url = $this->urlGenerator->generateFromRoute(
+          'erpw_location.delete_location',
+          ['tid' => $tid]
+        );
+        $edit_url = $this->urlGenerator->generateFromRoute(
+          'erpw_location.edit_location',
+          ['id' => $tid]
+        );
+        $view_url = $this->urlGenerator->generateFromRoute(
+          'erpw_location.view_location',
+          ['tid' => $tid, 'mode' => 'view']
         );
         $location_operations = '<div class="edit-delete-links">
           <span class="delete-link"><a href="' . $delete_url . '">' . $this->t('Delete') . '</a></span>


### PR DESCRIPTION
# Description:

Closes: #1386 

## Checklist:
Fixes the inconsistencies between active sub-domain and corresponding content for following forms:
- Manage Location > Add new location
- Manage Service > Add new service
- Manage Referral Pathway > Add new referral pathway

For form "Manage Application Users > Add new user", issue fixed in #1364 

